### PR TITLE
add ch_open option to avoid E906 on Windows

### DIFF
--- a/autoload/neovim_rpc.vim
+++ b/autoload/neovim_rpc.vim
@@ -35,7 +35,7 @@ func! neovim_rpc#serveraddr()
 	let g:_neovim_rpc_nvim_server     = l:servers[0]
 	let g:_neovim_rpc_vim_server = l:servers[1]
 
-	let g:_neovim_rpc_main_channel = ch_open(g:_neovim_rpc_vim_server)
+	let g:_neovim_rpc_main_channel = ch_open(g:_neovim_rpc_vim_server, {'waittime': -1})
 
 	" close channel before vim exit
 	" au VimLeavePre *  let s:leaving = 1 | execute s:py . ' neovim_rpc_server.stop()'


### PR DESCRIPTION
By default, `ch_open` doesn't wait opening the channel.
Under my environment(Windows 10, gvim), `neovim_rpc#serveraddr` gets `E906: not an open channel` error.
This change solves the error.
