### PR TITLE
Fix 29

### DIFF
--- a/autoload/neovim_rpc.vim
+++ b/autoload/neovim_rpc.vim
@@ -1,20 +1,20 @@
 
 
 if has('pythonx')
-	let s:py = 'pythonx'
-	let s:pyeval = function('pyxeval')
+    let s:py = 'pythonx'
+    let s:pyeval = function('pyxeval')
 elseif has('python3')
-	let s:py = 'python3'
-	let s:pyeval = function('py3eval')
+    let s:py = 'python3'
+    let s:pyeval = function('py3eval')
 else
-	let s:py = 'python'
-	let s:pyeval = function('pyeval')
+    let s:py = 'python'
+    let s:pyeval = function('pyeval')
 endif
 
 func! neovim_rpc#serveraddr()
-	if exists('g:_neovim_rpc_nvim_server')
-		return g:_neovim_rpc_nvim_server
-	endif
+    if exists('g:_neovim_rpc_nvim_server')
+        return g:_neovim_rpc_nvim_server
+    endif
 
     " must be utf-8
     if &encoding !=? "utf-8"
@@ -29,28 +29,28 @@ func! neovim_rpc#serveraddr()
         throw '[vim-hug-neovim-rpc] requires `:' . s:py . ' import neovim` command to work'
     endtry
 
-	execute s:py . ' import neovim_rpc_server'
-	let l:servers = s:pyeval('neovim_rpc_server.start()')
+    execute s:py . ' import neovim_rpc_server'
+    let l:servers = s:pyeval('neovim_rpc_server.start()')
 
-	let g:_neovim_rpc_nvim_server     = l:servers[0]
-	let g:_neovim_rpc_vim_server = l:servers[1]
+    let g:_neovim_rpc_nvim_server     = l:servers[0]
+    let g:_neovim_rpc_vim_server = l:servers[1]
 
-	let g:_neovim_rpc_main_channel = ch_open(g:_neovim_rpc_vim_server)
+    let g:_neovim_rpc_main_channel = ch_open(g:_neovim_rpc_vim_server)
 
-	" close channel before vim exit
-	" au VimLeavePre *  let s:leaving = 1 | execute s:py . ' neovim_rpc_server.stop()'
+    " close channel before vim exit
+    " au VimLeavePre *  let s:leaving = 1 | execute s:py . ' neovim_rpc_server.stop()'
 
-	" identify myself
-	call ch_sendexpr(g:_neovim_rpc_main_channel,'neovim_rpc_setup')
+    " identify myself
+    call ch_sendexpr(g:_neovim_rpc_main_channel,'neovim_rpc_setup')
 
-	return g:_neovim_rpc_nvim_server
+    return g:_neovim_rpc_nvim_server
 endfunc
 
 " elegant python function call wrapper
 func! neovim_rpc#pyxcall(func,...)
-	execute s:py . ' import vim, json'
+    execute s:py . ' import vim, json'
     let g:neovim_rpc#_tmp_args = copy(a:000)
-	let l:ret = s:pyeval(a:func . '(*vim.vars["neovim_rpc#_tmp_args"])')
+    let l:ret = s:pyeval(a:func . '(*vim.vars["neovim_rpc#_tmp_args"])')
     unlet g:neovim_rpc#_tmp_args
     return l:ret
 endfunc
@@ -62,43 +62,43 @@ endfunc
 " - detach
 func! neovim_rpc#jobstart(cmd,...)
 
-	let l:opts = {}
-	if len(a:000)
-		let l:opts = a:1
-	endif
+    let l:opts = {}
+    if len(a:000)
+        let l:opts = a:1
+    endif
 
     let l:opts['_close'] = 0
     let l:opts['_exit'] = 0
 
-	let l:real_opts = {'mode': 'raw'}
-	if has_key(l:opts,'detach') && l:opts['detach']
-		let l:real_opts['stoponexit'] = ''
-	endif
+    let l:real_opts = {'mode': 'raw'}
+    if has_key(l:opts,'detach') && l:opts['detach']
+        let l:real_opts['stoponexit'] = ''
+    endif
 
-	if has_key(l:opts,'on_stdout')
-		let l:real_opts['out_cb'] = function('neovim_rpc#_on_stdout')
-	endif
-	if has_key(l:opts,'on_stderr')
-		let l:real_opts['err_cb'] = function('neovim_rpc#_on_stderr')
-	endif
+    if has_key(l:opts,'on_stdout')
+        let l:real_opts['out_cb'] = function('neovim_rpc#_on_stdout')
+    endif
+    if has_key(l:opts,'on_stderr')
+        let l:real_opts['err_cb'] = function('neovim_rpc#_on_stderr')
+    endif
     let l:real_opts['exit_cb'] = function('neovim_rpc#_on_exit')
     let l:real_opts['close_cb'] = function('neovim_rpc#_on_close')
 
-	let l:job   = job_start(a:cmd, l:real_opts)
-	let l:jobid = ch_info(l:job)['id']
+    let l:job   = job_start(a:cmd, l:real_opts)
+    let l:jobid = ch_info(l:job)['id']
 
-	let g:_neovim_rpc_jobs[l:jobid] = {'cmd':a:cmd, 'opts': l:opts, 'job': l:job}
+    let g:_neovim_rpc_jobs[l:jobid] = {'cmd':a:cmd, 'opts': l:opts, 'job': l:job}
 
-	return l:jobid
+    return l:jobid
 endfunc
 
 func! neovim_rpc#jobstop(jobid)
-	let l:job = g:_neovim_rpc_jobs[a:jobid]['job']
-	return job_stop(l:job)
+    let l:job = g:_neovim_rpc_jobs[a:jobid]['job']
+    return job_stop(l:job)
 endfunc
 
 func! neovim_rpc#rpcnotify(channel,event,...)
-	call neovim_rpc#pyxcall('neovim_rpc_server.rpcnotify',a:channel,a:event,a:000)
+    call neovim_rpc#pyxcall('neovim_rpc_server.rpcnotify',a:channel,a:event,a:000)
 endfunc
 
 let s:rspid = 1
@@ -115,7 +115,7 @@ func! neovim_rpc#rpcrequest(channel, event, ...)
 
     let expr = 'json.dumps(neovim_rpc_server.responses.pop("' . rspid . '"))'
 
-	execute s:py ' import neovim_rpc_server, json'
+    execute s:py ' import neovim_rpc_server, json'
     let [err, result] = json_decode(s:pyeval(expr))
     if err
         if type(err) == type('')
@@ -127,22 +127,22 @@ func! neovim_rpc#rpcrequest(channel, event, ...)
 endfunc
 
 func! neovim_rpc#_on_stdout(job,data)
-	let l:jobid = ch_info(a:job)['id']
-	let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
-	" convert to neovim style function call
-	call call(l:opts['on_stdout'],[l:jobid,split(a:data,"\n",1),'stdout'],l:opts)
+    let l:jobid = ch_info(a:job)['id']
+    let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
+    " convert to neovim style function call
+    call call(l:opts['on_stdout'],[l:jobid,split(a:data,"\n",1),'stdout'],l:opts)
 endfunc
 
 func! neovim_rpc#_on_stderr(job,data)
-	let l:jobid = ch_info(a:job)['id']
-	let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
-	" convert to neovim style function call
-	call call(l:opts['on_stderr'],[l:jobid,split(a:data,"\n",1),'stderr'],l:opts)
+    let l:jobid = ch_info(a:job)['id']
+    let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
+    " convert to neovim style function call
+    call call(l:opts['on_stderr'],[l:jobid,split(a:data,"\n",1),'stderr'],l:opts)
 endfunc
 
 func! neovim_rpc#_on_exit(job,status)
-	let l:jobid = ch_info(a:job)['id']
-	let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
+    let l:jobid = ch_info(a:job)['id']
+    let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
     let l:opts['_exit'] = 1
     " cleanup when both close_cb and exit_cb is called
     if l:opts['_close'] && l:opts['_exit']
@@ -155,8 +155,8 @@ func! neovim_rpc#_on_exit(job,status)
 endfunc
 
 func! neovim_rpc#_on_close(job)
-	let l:jobid = ch_info(a:job)['id']
-	let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
+    let l:jobid = ch_info(a:job)['id']
+    let l:opts = g:_neovim_rpc_jobs[l:jobid]['opts']
     let l:opts['_close'] = 1
     " cleanup when both close_cb and exit_cb is called
     if l:opts['_close'] && l:opts['_exit']
@@ -165,7 +165,7 @@ func! neovim_rpc#_on_close(job)
 endfunc
 
 func! neovim_rpc#_callback()
-	execute s:py . ' neovim_rpc_server.process_pending_requests()'
+    execute s:py . ' neovim_rpc_server.process_pending_requests()'
 endfunc
 
 let g:_neovim_rpc_main_channel = -1


### PR DESCRIPTION
Another attempt to fix #29 

This PR tries to avoid data loss compared to PR #30. We cleanup the job data only when both `exit_cb` and `close_cb` are called

@Shougo

I think this PR is probably better. However I cannot reproduce #29. @dylan-chong  Would you like to test it since #29 is reproducible on your PC?