### PR TITLE
Fix module name

### DIFF
--- a/autoload/neovim_rpc.vim
+++ b/autoload/neovim_rpc.vim
@@ -24,13 +24,13 @@ func! neovim_rpc#serveraddr()
     endif
 
     try
-        call s:py('import neovim')
+        call s:py('import pynvim')
     catch
         call neovim_rpc#_error("failed executing: " .
-                    \ g:neovim_rpc#py . " import neovim")
+                    \ g:neovim_rpc#py . " import pynvim")
         call neovim_rpc#_error(v:exception)
         throw '[vim-hug-neovim-rpc] requires `:' . g:neovim_rpc#py .
-                    \ ' import neovim` command to work'
+                    \ ' import pynvim` command to work'
     endtry
 
     call s:py('import neovim_rpc_server')


### PR DESCRIPTION
Now `neovim` module has been renamed as `pynvim`.