### PR TITLE
Add nvim_get_current_line

### DIFF
--- a/pythonx/neovim_rpc_methods.py
+++ b/pythonx/neovim_rpc_methods.py
@@ -103,6 +103,10 @@ def nvim_command(cmd):
     vim.command(cmd)
 
 
+def nvim_get_current_line():
+    return vim.current.line
+
+
 def nvim_get_current_win():
     return vim.current.window
 


### PR DESCRIPTION
Adds missing api call needed by plugin Shougo/denite.nvim