### PR TITLE
fallback to neovim if pynvim cannot be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ open a PR if you get any idea on improving it**.
     - [pynvim](https://github.com/neovim/pynvim)
     - Pynvim is normally installed by `:py3 import pip; pip.main(['install',
         '--user', 'pynvim'])` or `python3 -m pip install pynvim`.
-    - There should be no error when you execute `:python3 import pynvim`
+    - There should be no error for at least one of `:python3 import pynvim` and
+        `:python3 import neovim`
 5. Else if `has('python')`
     - [pynvim](https://github.com/neovim/pynvim)
     - Pynvim is normally installed by `:py import pip; pip.main(['install',
         '--user', 'pynvim'])` or `python2 -m pip install pynvim`.
-    - There should be no error when you execute `:python import pynvim`
+    - There should be no error for at least one of `:python3 import pynvim` and
+        `:python3 import neovim`
 6. `set encoding=utf-8` in your vimrc.
 
 ***Use `:echo neovim_rpc#serveraddr()` to test the installation***. It should print

--- a/autoload/neovim_rpc.vim
+++ b/autoload/neovim_rpc.vim
@@ -26,11 +26,15 @@ func! neovim_rpc#serveraddr()
     try
         call s:py('import pynvim')
     catch
-        call neovim_rpc#_error("failed executing: " .
-                    \ g:neovim_rpc#py . " import pynvim")
-        call neovim_rpc#_error(v:exception)
-        throw '[vim-hug-neovim-rpc] requires `:' . g:neovim_rpc#py .
-                    \ ' import pynvim` command to work'
+        try
+            call s:py('import neovim')
+        catch
+            call neovim_rpc#_error("failed executing: " .
+                        \ g:neovim_rpc#py . " import [pynvim|neovim]")
+            call neovim_rpc#_error(v:exception)
+            throw '[vim-hug-neovim-rpc] requires one of `:' . g:neovim_rpc#py .
+                        \ ' import [pynvim|neovim]` command to work'
+        endtry
     endtry
 
     call s:py('import neovim_rpc_server')


### PR DESCRIPTION
Some distributions, such as Debian, have not yet updated adopted the
changed pynvim package name and still use neovim. If importing pynvim
fails try to import neovim. If that also fails error as usual.

Signed-off-by: Melvin Vermeeren <mail@mel.vin>