### PR TITLE
Fix hanging by KeyboardInterrupt

### DIFF
--- a/pythonx/neovim_rpc_server.py
+++ b/pythonx/neovim_rpc_server.py
@@ -399,6 +399,9 @@ def process_pending_requests():
                     # error uccor
                     err = [1, str(ex)]
                     result = None
+                except KeyboardInterrupt:
+                    err = [1, "Keyboard interrupt"]
+                    result = None
 
                 result = [1, req_id, err, result]
                 logger.info("sending result: %s", result)
@@ -413,6 +416,8 @@ def process_pending_requests():
                     logger.info('notification process result: [%s]', result)
                 except Exception as ex:
                     logger.exception("process failed: %s", ex)
+                except KeyboardInterrupt:
+                    pass
 
         except QueueEmpty:
             pass


### PR DESCRIPTION
Fix hanging by `KeyboardInterrupt` exception.

This hanging occurrs when typing `<C-C>` after `nvim.call('input', '')`.
`KeyboardInterrupt` is not derived from `Exception` class, then no error reply was returned.
