### PR TITLE
Can specify g:neovim_rpc#py

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ open a PR if you get any idea on improving it**.
     - There should be no error for at least one of `:python3 import pynvim` and
         `:python3 import neovim`
 6. `set encoding=utf-8` in your vimrc.
+7. `g:neovim_rpc#py` pointed to your python3 executable, or `echo
+exepath('python3')` is not empty.
 
 ***Use `:echo neovim_rpc#serveraddr()` to test the installation***. It should print
 something like `127.0.0.1:51359` or `/tmp/vmrUX9X/2`.

--- a/autoload/neovim_rpc.vim
+++ b/autoload/neovim_rpc.vim
@@ -1,12 +1,18 @@
 
 if has('pythonx')
-    let g:neovim_rpc#py = 'pythonx'
+    if !exists('g:neovim_rpc#py')
+        let g:neovim_rpc#py = 'pythonx'
+    endif
     let s:pyeval = function('pyxeval')
 elseif has('python3')
-    let g:neovim_rpc#py = 'python3'
+    if !exists('g:neovim_rpc#py')
+        let g:neovim_rpc#py = 'python3'
+    endif
     let s:pyeval = function('py3eval')
 else
-    let g:neovim_rpc#py = 'python'
+    if !exists('g:neovim_rpc#py')
+        let g:neovim_rpc#py = 'python'
+    endif
     let s:pyeval = function('pyeval')
 endif
 


### PR DESCRIPTION
Fix #64.

@roxma In nvim-yarp, user needs to set `g:python3_host_prog` to specify.
But in vim-hug-neovim-rpc is not(`g:neovim_rpc#py`).
I think the interface should be same?